### PR TITLE
 fix `sphinx_rtd_theme` lines in tables wrapping

### DIFF
--- a/docs/source/_static/hackrtd.css
+++ b/docs/source/_static/hackrtd.css
@@ -110,3 +110,17 @@ a.trio-help-hint, .trio-help-hint a:link, .trio-help-hint a:visited {
     text-decoration: none;
     border-bottom: 1px solid;
 }
+
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/source/_static/hackrtd.css
+++ b/docs/source/_static/hackrtd.css
@@ -120,7 +120,17 @@ a.trio-help-hint, .trio-help-hint a:link, .trio-help-hint a:visited {
       white-space: normal !important;
    }
 
+   .wy-table-responsive table th {
+      /* This is a trio specific override since we have long header names compared to other projects who've had issues
+         with wide tables (allowing wrapping just in the cells isn't enough to shrink tables meaningfully).
+         */
+      white-space: normal !important;
+   }
+
    .wy-table-responsive {
+      /* This makes very wide tables look ugly and extend past their parent... Maybe allowing the scroll bar isn't so
+         bad in comparison (after the above 2 fixes).
+         */
       overflow: visible !important;
    }
 }


### PR DESCRIPTION
* `sphinx_rtd_theme` known issue: long lines in tables do not wrap by default
  - readthedocs/sphinx_rtd_theme#117